### PR TITLE
fix: User Secrets設定時のプロジェクト指定エラーを修正

### DIFF
--- a/Doc/SETUP_DB.md
+++ b/Doc/SETUP_DB.md
@@ -13,8 +13,8 @@
 ソースコード内の `appsettings.json` にはパスワードを記述しないでください。代わりに以下のコマンドをターミナルで実行して、ローカルマシンにのみ保存されるシークレットを設定します。
 
 ```powershell
-# プロジェクトディレクトリ (Source/DcScrapingPlatform) で実行
-dotnet user-secrets set "ConnectionStrings:DefaultConnection" "コピーした接続文字列"
+# プロジェクトルートで実行
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "コピーした接続文字列" --project Source/DcScrapingPlatform
 ```
 
 ## 3. 動作確認

--- a/Doc/ローカルデバッグ手順書.md
+++ b/Doc/ローカルデバッグ手順書.md
@@ -23,11 +23,8 @@
 機密情報を `appsettings.json` に記述せず、`.NET User Secrets` を使用して管理します。以下のコマンドをターミナル（PowerShell 等）で実行してください。
 
 ```powershell
-# プロジェクトディレクトリへ移動
-cd Source/DcScrapingPlatform
-
 # 接続文字列を設定 (YOUR_CONNECTION_STRING を実際の値に置き換えてください)
-dotnet user-secrets set "ConnectionStrings:DefaultConnection" "YOUR_CONNECTION_STRING"
+dotnet user-secrets set "ConnectionStrings:DefaultConnection" "YOUR_CONNECTION_STRING" --project Source/DcScrapingPlatform
 ```
 
 ## 3. 実行方法


### PR DESCRIPTION
User Secrets設定時のプロジェクト指定エラーの修正

`dotnet user-secrets` コマンドをプロジェクトルートから実行した際に、`.csproj` ファイルが見つからずエラーになる問題を解決するため、ドキュメントを修正しました。

## 変更内容
- `Doc/SETUP_DB.md` および `Doc/ローカルデバッグ手順書.md` 内のコマンドに `--project Source/DcScrapingPlatform` オプションを追加。
- これにより、ディレクトリを移動することなくプロジェクトルートから設定コマンドを実行可能になりました。

Closes #8
