### PR TITLE
詳細設計書の更新（基本・画面設計書の反映）

### DIFF
--- a/Doc/詳細設計書.md
+++ b/Doc/詳細設計書.md
@@ -1,24 +1,24 @@
 # 詳細設計書 - DcScrapingPlatform
 
-## 1. 接続・秘密管理
-- **構成**: 本番(Main branch)と開発(Dev branch)を分離。
-- **管理**: 
+## 1. システム構成と管理
+- **機密情報管理**: 
   - ローカル開発: `.NET User Secrets` (secrets.json)
-  - 本番/検証: 環境変数 (SECRET_CONNECTION_STRING 等)
-- **運用**: `appsettings.json` には機密情報を含めない。
+  - 本番/検証: Azure Key Vault または環境変数 (SECRET_CONNECTION_STRING 等)
+  - `appsettings.json` には機密情報を含めず、テンプレートのみを配置。
+- **環境分離**: Neon (PostgreSQL) のブランチ機能を利用し、`main`（本番）と `dev`（開発）を分離。
 
-## 1. データベース設計
+## 2. データベース設計
 
-### 1.1 AspNetUsers (Identity 標準)
+### 2.1 AspNetUsers (Identity 標準)
 ユーザー認証情報を管理。
 
-### 1.2 Profiles
+### 2.2 Profiles
 ユーザー固有の設定を管理。
 - `UserId`: `string` (FK to AspNetUsers.Id)
 - `SpreadsheetId`: `string` (Google Sheets ID)
 - `UpdatedAt`: `DateTime`
 
-### 1.3 DcCredentials
+### 2.3 DcCredentials
 暗号化されたログイン情報を管理。
 - `UserId`: `string` (FK to AspNetUsers.Id)
 - `EncryptedId`: `byte[]` (AES暗号化)
@@ -26,7 +26,7 @@
 - `Iv`: `byte[]` (初期化ベクトル)
 - `UpdatedAt`: `DateTime`
 
-### 1.4 AssetHistories
+### 2.4 AssetHistories
 過去の資産推移データを保持。
 - `Id`: `int` (PK)
 - `UserId`: `string` (FK)
@@ -34,13 +34,28 @@
 - `ProfitLoss`: `decimal` (評価損益)
 - `RecordedAt`: `DateTime` (取得日時)
 
-## 2. アプリケーションアーキテクチャ
+### 2.5 ScrapingLogs (NEW)
+スクレイピングの実行履歴とステータスを管理（画面設計のタスク一覧に対応）。
+- `Id`: `int` (PK)
+- `UserId`: `string` (FK)
+- `Status`: `int` (0: 待機中, 1: 実行中, 2: 完了, 3: エラー)
+- `Message`: `string` (エラー詳細など)
+- `StartedAt`: `DateTime`
+- `FinishedAt`: `DateTime?`
 
-### 2.1 レイヤー構成
-- **Components (UI)**: Blazor コンポーネント (MudBlazor)
-- **Controllers/Endpoints**: データ登録、ステータス確認用 API
-- **Services**: 暗号化、スクレイピング実行指令、DB 操作、Google API 連携
-- **Data (EF Core)**: `ApplicationDbContext` による DB アクセス
+## 3. アプリケーションアーキテクチャ
+
+### 3.1 レイヤー構成 (Blazor Web App - Interactive Auto)
+- **Client Project (WASM)**: 
+  - UI プレゼンテーション、クライアントサイドバリデーション。
+  - `MudBlazor` コンポーネントによる高速な UI 応答。
+- **Server Project (ASP.NET Core)**:
+  - **Endpoints**: Web API (データ取得・アクション指示)
+  - **Services**: 
+    - `EncryptionService`: AES 暗号化/復号
+    - `ScrapingService`: Playwright を用いたスクレイピング制御
+    - `ExportService`: Google Sheets API 連携
+  - **Data**: Entity Framework Core (`ApplicationDbContext`)
 
 ## 3. 主要処理フロー
 
@@ -58,13 +73,23 @@
 3. `MASTER_ENCRYPTION_KEY` と `Iv` を用いて平文を `Aes` 暗号化。
 4. 暗号化データと `Iv` を `DcCredentials` テーブルへ保存。
 
-## 4. UI 設計 (MudBlazor)
+## 5. UI 詳細設計 (MudBlazor)
 
-### 4.1 ダッシュボード
-- `MudChart`: 資産推移を時系列で表示。
-- `MudDataGrid`: 最新の資産内訳（ファンド名、評価額、損益等）をグリッド表示。
-- `MudAlert`: スクレイピング失敗時の通知。
+### 5.1 トップページ / 認証画面
+- `MudText`: ヒーローセクションのキャッチコピー
+- `MudButton`: ログイン（Variant.Filled, Color.Primary）、アカウント登録（Variant.Outlined）
+- `MudTextField`: 入力項目（バリデーションには `MudForm` と配合）
 
-### 4.2 設定画面
-- `MudTextField`: スプレッドシート ID やログイン情報の入力。
-- `MudButton`: 暗号化保存およびテスト実行。
+### 5.2 ダッシュボード
+- **サマリーカード**: `MudPaper` + `MudText` で実行数・エラー数・総計を表示。
+- **資産推移グラフ**: `MudChart` (ChartType.Line)
+- **タスク一覧**: `MudDataGrid` を使用し、以下のカラムを表示。
+  - ターゲット（UFJ確定拠出年金）
+  - ステータス（`MudChip` で色分け: Success, Error, Warning, Info）
+  - 最終更新日
+  - アクション（即時実行ボタン、ログ表示）
+
+### 5.3 アカウント・連携設定
+- `MudTabs`: 基本情報と DC 連携設定をタブで切り替え。
+- `MudTextField`: スプレッドシート ID, スクレイピング用ログイン ID, パスワード（InputType.Password）。
+- `MudMessageBox`: アカウント削除等の危険操作時の確認ダイアログ。


### PR DESCRIPTION
基本設計書および画面設計書の内容を反映し、詳細設計書を更新しました。

## 変更内容
- セクション番号の重複（1. が複数存在）を修正しました。
- 画面設計の「タスク一覧」に対応するため、`ScrapingLogs` テーブルの設計を追加しました。
- UIコンポーネントの詳細設計に、具体的な MudBlazor のコントロール（`MudDataGrid`, `MudChart` 等）を追記しました。
- Blazor Web App (Interactive Auto) における Client/Server の役割分担を整理しました。

Closes #14
