### PR TITLE
docs: 案1（Worker Service方式）に基づくアーキテクチャ設計の修正

### DIFF
--- a/Doc/基本設計書.md
+++ b/Doc/基本設計書.md
@@ -11,6 +11,9 @@
 ## 3. システム構成
 ### 3.1 技術スタック
 - **Web App**: ASP.NET Core 10 (Blazor Web App)
+- **Client App**: Blazor WebAssembly (Shared UI)
+- **Worker App**: .NET 10 Console App (Background Worker)
+- **Shared Library**: .NET 10 Class Library (Models, Data, Common Logic)
 - **UI Framework**: MudBlazor
 - **Database**: Neon (Serverless PostgreSQL)
 - **ORM**: Entity Framework Core
@@ -18,9 +21,10 @@
 - **Scraping**: Playwright (.NET)
 
 ### 3.2 インフラ構成
-- **Hosting**: Azure App Service / Render (Free Tier)
+- **Hosting (Web)**: Azure App Service / Render (Free Tier)
+- **Hosting (Worker)**: Azure Container Apps / Render (Background Worker)
 - **Database Hosting**: Neon.tech (本番: Main Branch, 開発: Dev Branches)
-- **Automation**: GitHub Actions (定時スクレイピング実行)
+- **Automation**: GitHub Actions (定時スクレイピング実行・CI/CD)
 
 ## 4. 機能一覧
 ### 4.1 ユーザー管理機能
@@ -41,8 +45,10 @@
 - **実行状況の確認**: スクレイピングが待機中、実行中、完了、またはエラーであるかの確認。
 
 ### 4.4 自動スクレイピング機能
-- 定期実行（Cron）によるデータ取得
-- Google Sheets へのデータ追記
+- **実行依頼方式**: Web アプリから DB を介して非同期に依頼。
+- **バックグラウンド実行**: Worker アプリによる独立したスクレイピング処理。
+- **定期実行（Cron）**: GitHub Actions 等から定期的に Worker をキック、または Worker 自体でスケジュール実行。
+- **データ連携**: 取得した資産データを DB に保存し、Google Sheets へ追記。
 
 ## 5. セキュリティ設計
 - **データ暗号化**: UFJ サイトのログイン情報は `Aes` クラスを用いてアプリケーション層で暗号化。

--- a/Doc/詳細設計書.md
+++ b/Doc/詳細設計書.md
@@ -45,28 +45,35 @@
 
 ## 3. アプリケーションアーキテクチャ
 
-### 3.1 レイヤー構成 (Blazor Web App)
-- **Client Project (WASM)**: 
+### 3.1 レイヤー構成
+- **DcScrapingPlatform.Client (WASM)**: 
   - ダッシュボードや設定画面などのインタラクティブな UI プレゼンテーション。
-  - `MudBlazor` コンポーネントによる高速な UI 応答。
-- **Server Project (ASP.NET Core)**:
-  - **Account/Identity (SSR)**: 認証、アカウント登録、ログイン、ログアウトをサーバーサイドの静的 SSR で処理（クッキー認証の確実な反映のため）。
-  - **Endpoints**: Web API (スクレイピング履歴取得、資産データ取得等)。
+- **DcScrapingPlatform (Web Server)**:
+  - **Account/Identity (SSR)**: 認証に関連する処理（Cookie 認証）。
+  - **Endpoints**: クライアント用の Web API。
   - **Services**: 
-    - `EncryptionService`: AES 暗号化/復号
-    - `ScrapingService`: Playwright を用いたスクレイピング制御
-    - `ExportService`: Google Sheets API 連携
-  - **Data**: Entity Framework Core (`ApplicationDbContext`)
+    - `ScrapingService`: DB（`ScrapingLogs`）へ「待機中」レコードを作成し、Worker へ処理を委ねる。
+    - `ExportService`: Google Sheets API 連携（Web or Workerで必要に応じて実行）。
+- **DcScrapingPlatform.Worker (Background Service)**:
+  - **Role**: 長時間の処理（Playwright によるスクレイピング）を担当。
+  - **Logic**: DB をポーリングし、`Status = 0` (待機中) のログを処理。
+  - **Services**: 
+    - `ScrapingEngine`: 実際の Playwright 操作。
+- **DcScrapingPlatform.Shared (Class Library)**:
+  - **Data**: `ApplicationDbContext`, `Migrations`
+  - **Models**: `ApplicationUser`, `AssetHistory`, `ScrapingLog`, `DcCredential`
+  - **Services**: `EncryptionService` (AES 暗号化/復号)
 
 ## 3. 主要処理フロー
 
-### 3.1 スクレイピング実行フロー
-1. GitHub Actions または定期 Job がトリガー。
-2. 対象ユーザーの `DcCredentials` を取得し、`MASTER_ENCRYPTION_KEY` で復号。
-3. Playwright を起動し、DC サイトへログイン。
-4. 資産合計および個別銘柄情報を抽出。
-5. **最新の合計評価額等を `AssetHistories` テーブルに保存。**
-6. ユーザーの `SpreadsheetId` に基づき、Google Sheets へ追記（バックアップ用）。
+### 3.1 スクレイピング実行フロー (非同期分離型)
+1. **トリガー**: ユーザーが画面から実行ボタンを押下、または定時 Job。
+2. **Web App**: `ScrapingLogs` テーブルに `Status = 0` (待機中) のレコードを作成。
+3. **Worker**: 数秒おきに DB をポーリングし、`Status = 0` のレコードを取得。
+4. **Worker**: 該当レコードを `Status = 1` (実行中) に更新。
+5. **Worker**: `DcCredentials` を復号し、Playwright でスクレイピング実行。
+6. **Worker**: 完了後、`AssetHistories` および `ScrapingLogs` (Status = 2) を更新。
+7. **Worker**: Google Sheets へデータを追記。
 
 ### 3.2 ログイン情報の保存フロー
 1. ユーザーが平文で ID/PASS を入力。

--- a/Walkthrough/20260318_2115_feature_#39-arch-design-update/walkthrough.md
+++ b/Walkthrough/20260318_2115_feature_#39-arch-design-update/walkthrough.md
@@ -1,0 +1,28 @@
+# ウォークスルー - アーキテクチャ設計の修正
+
+## 概要
+スクレイピング処理を別プロジェクト（Worker Service）に分離する「案1」の採用に伴い、プロジェクトの基本設計および詳細設計を修正しました。
+
+## 修正内容
+
+### 1. 基本設計の更新 ([基本設計書.md](../../Doc/基本設計書.md))
+- **技術スタック**: `DcScrapingPlatform.Worker` (Console App) と `DcScrapingPlatform.Shared` (Class Library) を追加。
+- **インフラ構成**: Worker のホスティング先として Azure Container Apps 等を想定。
+- **機能一覧**: スクレイピングが Web アプリから非同期で依頼され、Worker で実行される仕組みを明記。
+
+### 2. 詳細設計の更新 ([詳細設計書.md](../../Doc/詳細設計書.md))
+- **レイヤー構成**: 以下の 4層構造に整理。
+    - `Client`: インタラクティブ UI
+    - `Web`: API / SSR / 実行依頼
+    - `Worker`: スクレイピング実効
+    - `Shared`: DB / モデル / 共通ロジック
+- **処理フロー**: DB (`ScrapingLogs`) をキューとして使用する非同期実行フローを定義。
+
+## 証跡
+- **GitHub Issue**: #39
+- **Pull Request**: [#40](https://github.com/shimizu-tkmt/DcScrapingPlatform/pull/40)
+
+## 次のステップ
+1. ユーザーによる PR のマージ。
+2. マージ後、`feature/#39-arch-design-update` ブランチの削除。
+3. Shared プロジェクトの作成および既存ロジックの移行作業の開始。


### PR DESCRIPTION
Closes #39

案1（Worker Service方式）に基づき、スクレイピング処理を別プロジェクトに分離するためのアーキテクチャ設計（基本設計・詳細設計）を修正しました。

## 修正内容
- **Doc/基本設計書.md**: 技術スタック、インフラ構成、機能一覧に Worker と Shared プロジェクトを追加。
- **Doc/詳細設計書.md**: レイヤー構成を 4層（Client, Web, Worker, Shared）に整理し、非同期分離型のスクレイピング実行フローを定義。
